### PR TITLE
Fixed compatibilty with other tweaks that hook `SpringBoard`

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -67,7 +67,7 @@
 	[mainWindow setHidden:YES];
 	[mainWindow setUserInteractionEnabled:NO];
 	[mainWindow makeKeyAndVisible];
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:@"QuickSearchNotification" object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(setupSearchBar) name:@"QuickSearchNotification" object:nil];
 }
 


### PR DESCRIPTION
Hey, I'm making this new PR to fix my previous one 😂. I forgot removing `self` entirely as the observer would break compatibility with similar tweaks, such as PencilBanner. One dude couldn't get it working and when they mentioned QuickSearch was the culprit I remembered this, since I once had the same issue with my own tweak when trying to figure out why the compatibility was broken. Anyways, so just removing the observer with the given notification name is the fix 👍🏽.